### PR TITLE
fix: content length in head request with reqwest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,11 @@ impl<Data: Send + Sync + 'static> Fetcher<Data> {
                 let head_response = head_reqwest(client, &*uris[0]).await?;
 
                 if let Some(response) = head_response.as_ref() {
-                    length = response.content_length();
+                    length = response
+                            .headers()
+                            .get(reqwest::header::CONTENT_LENGTH)
+                            .and_then(|value| value.to_str().ok())
+                            .and_then(|value| value.parse().ok());
                     modified = response.last_modified();
                 }
             }


### PR DESCRIPTION
Thank you for this great library! We are using it on an embedded device to download firmware updates.

When using it with the reqwest feature, the content-length was always reported as 0, which in turn disabled the download resume feature.

The reason was reqwest's `response.content_length()` call which checks the body length and not the content-length header value.